### PR TITLE
WIP - 10-10-2018 Improvements to Setup/Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin/
 vendor/
 .env
-junk
-notes.md
 config.yml
 config.json
+ext-results/
+

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,11 @@
 default: build
 
-GOCMD := $(shell which go)
-GOBAK := $(GOCMD).bak
-
 setup:
-	@echo GOCMD is set to: $(GOCMD)
-	@echo GOBAK is set to: $(GOBAK)
 	go install github.com/golang/dep/cmd/dep
-	sudo cp $(GOCMD) $(GOBAK)
-	sudo cp $(PWD)/bin/go-cover $(GOCMD)
+	sudo ./build/setup.sh
 
 clean:
-	sudo mv $(GOBAK) $(GOCMD)
+	sudo ./build/clean.sh
 
 build:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -60,5 +60,13 @@ A neighborhood watch tool for evaluating neighbors' test suite adequacy in the n
     make run
     ```
 
+    neighbor will use the GitHub query specified in the config file to find projects
+    on GitHub. neighbor will then clone each of these projects. After cloning all
+    of the projects, neighbor will sequentially test each of the projects using the
+    test command specified in the config. neighbor will use a custom go binary
+    instead of the default go binary. This custom go binary always enables the
+    `-coverprofile` flag during `go test` and writes to a easy-to-find location
+    at the root of each project in the `_ext-results/` directory.
+
 ## License
 + [GNU General Public License Version 3](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # neighbor
 ---
-
-A neighborhood watch for testing on GitHub.
+A neighborhood watch tool for evaluating neighbors' test suite adequacy in the neighborhood, GitHub projects.
 
 ## Requirements
 + [Go](https://golang.org/dl/)
@@ -11,26 +10,26 @@ A neighborhood watch for testing on GitHub.
 1. Installing the project
     1. `cd $HOME/go`
     2. `go get -u -v github.com/mccurdyc/neighbor`
-2. Start SSH Agent and Add Keys to Agent
-    1. Start SSH Agent
-    ```
-    eval `ssh-agent -s`
-    ```
-    2. Add SSH Keys (your setup may differ, but generally you can do the following)
-    ```
-    ssh-add $HOME/.ssh/id_rsa
-    ```
-3. Run the Setup
+2. Prepare neighbor for Execution
     ```bash
     make setup
     ```
 
     The `setup` `make` target will do the following:
     1. Install `dep`
-    2. Backup YOUR installed version of `go` (`which go`) to the value returned
-      from `which go` with a file extension `.bak` appended
-    3. Move `./bin/go-cover` to `which go` to be used as the system-wide `go` command
-      + you can verify this by running `go version` after running `make setup`
+    2. Create a `config.json` file from the `sample.config.json` file
+
+      **NOTE: You still need to update the access token in the config file to use your personal access token.**
+
+      **NOTE: The setup target will check to see if you have already copied the sample.config.json to
+      config.json for execution. If you have, the setup will not overwrite the config.json file.**
+    3. Backup your installed version of `go` (`$ which go`) to the value returned
+      from `$ which go` in your shell with a file extension `.bak` appended.
+
+      **NOTE: The setup target will check to see if you have already backed up a go command. If you have,
+      the setup will not overwrite the backup.**
+    4. Move `./bin/go-cover` to `which go` to be used as the system-wide `go` command
+      + You can verify this by running `go version` after running `make setup`
           + If you see something similar to the following, then you are still
             running an officially-released version of `go`.
               ```bash
@@ -40,15 +39,23 @@ A neighborhood watch for testing on GitHub.
               ```bash
               go version devel +2afdd17e3f Mon Oct 8 19:13:38 2018 +0000 linux/amd64
               ```
-4. Generate a [Personal Access Token on GitHub](https://github.com/settings/tokens)
-    + Add generated token to the GitHub configuration file
+3. Generate a [Personal Access Token on GitHub](https://github.com/settings/tokens)
+    neighbor uses token authentication for communicating and authenticating with GitHub.
+    To read more about GitHub's token authentication, visit [this site](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+
+    > You can create a personal access token and use it in place of a password when performing Git operations over HTTPS with Git on the command line or the API.
+
+    Authentication is required to both increase the [GitHub API limitations](https://godoc.org/github.com/google/go-github/github#hdr-Rate_Limiting)
+    as well as access private content (e.g., repositories, gists, etc.).
+
+    + Add the generated token to the configuration file (`config.json`).
       ```json
       {
-        "access_token": "1234567890abcdefghijklmnopqrstuvwxyz",
+        "access_token": "yourAccessToken1234567890abcdefghijklmnopqrstuvwxyz",
         ...
       }
       ```
-5. Run neighbor
+4. Performing a neighborhood analysis with neighbor
     ```bash
     make run
     ```

--- a/build/clean.sh
+++ b/build/clean.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+SYS_GOCMD=$(which go)
+GOBAK="$SYS_GOCMD.bak"
+
+NEIGHBOR_DIR=$(pwd)
+NEIGHBOR_GOCMD="$NEIGHBOR_DIR/bin/go-cover"
+
+# will need to be run as `root`
+if [ -f $GOBAK ]; then
+  echo "Moving backup $GOBAK back to $SYS_GOCMD."
+  mv $GOBAK $SYS_GOCMD
+else
+  echo "Backup ($GOBAK) doesn't exist; doing nothing."
+fi

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -4,6 +4,15 @@ GOBAK="$SYS_GOCMD.bak"
 
 NEIGHBOR_DIR=$(pwd)
 NEIGHBOR_GOCMD="$NEIGHBOR_DIR/bin/go-cover"
+NEIGHBOR_CFG="$NEIGHBOR_DIR/config.json"
+NEIGHBOR_SAMPLE_CFG="$NEIGHBOR_DIR/sample.config.json"
+
+if [ -f $NEIGHBOR_CFG ]; then
+  echo "neighbor config already exists ($NEIGHBOR_CFG), doing nothing."
+else
+  echo "Creating a neighbor config file ($NEIGHBOR_CFG) from the sample config."
+	cp $NEIGHBOR_SAMPLE_CFG $NEIGHBOR_CFG
+fi
 
 # will need to be run as `root`
 if [ -f $GOBAK ]; then

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+SYS_GOCMD=$(which go)
+GOBAK="$SYS_GOCMD.bak"
+
+NEIGHBOR_DIR=$(pwd)
+NEIGHBOR_GOCMD="$NEIGHBOR_DIR/bin/go-cover"
+
+# will need to be run as `root`
+if [ -f $GOBAK ]; then
+  echo "Not backing up go command, a backup already exists ($GOBAK)."
+else
+  echo "Backing up $SYS_GOCMD to $GOBAK."
+  cp $SYS_GOCMD $GOBAK
+  echo "Replacing $SYS_GOCMD with $NEIGHBOR_GOCMD."
+	cp $NEIGHBOR_GOCMD $SYS_GOCMD
+fi

--- a/cmd/neighbor/main.go
+++ b/cmd/neighbor/main.go
@@ -34,8 +34,11 @@ func main() {
 
 	// create a context object that will be used for the life of the program and passed around
 	ctx := &neighbor.Ctx{
-		Config:        cfg,
-		Context:       context.Background(),
+		Config:  cfg,
+		Context: context.Background(),
+		GitHub: neighbor.GitHubDetails{
+			AccessToken: cfg.Contents.AccessToken,
+		},
 		Logger:        l,
 		NeighborDir:   wd,
 		ProjectDirMap: make(map[string]string),

--- a/pkg/github/clone.go
+++ b/pkg/github/clone.go
@@ -2,7 +2,8 @@ package github
 
 import (
 	// stdlib
-	"io/ioutil"
+
+	"fmt"
 	"os"
 
 	// external
@@ -33,12 +34,8 @@ func CloneFromResult(ctx *neighbor.Ctx, c *github.Client, d interface{}) {
 	case *github.RepositoriesSearchResult:
 		for _, r := range t.Repositories {
 
-			dir, err := ioutil.TempDir("", *r.Name)
-			if err != nil {
-				return
-			}
-
-			ctx.Logger.Infof("created temp directory: %s", dir)
+			dir := fmt.Sprintf("%s/%s", ctx.ExtResultDir, *r.Name)
+			ctx.Logger.Infof("created directory: %s", dir)
 
 			sshAuth, err := ssh.NewSSHAgentAuth("git") // username has to be "git" - https://github.com/src-d/go-git/issues/637
 			if err != nil {

--- a/pkg/github/clone.go
+++ b/pkg/github/clone.go
@@ -9,7 +9,7 @@ import (
 	// external
 	"github.com/google/go-github/github"
 	git "gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 
 	// internal
 	"github.com/mccurdyc/neighbor/pkg/neighbor"
@@ -34,22 +34,25 @@ func CloneFromResult(ctx *neighbor.Ctx, c *github.Client, d interface{}) {
 	case *github.RepositoriesSearchResult:
 		for _, r := range t.Repositories {
 
+			ctx.Logger.Debugf("%+v", r)
 			dir := fmt.Sprintf("%s/%s", ctx.ExtResultDir, *r.Name)
 			ctx.Logger.Infof("created directory: %s", dir)
 
-			sshAuth, err := ssh.NewSSHAgentAuth("git") // username has to be "git" - https://github.com/src-d/go-git/issues/637
-			if err != nil {
-				ctx.Logger.Errorf("failed to create new ssh agent with error %+v", err)
-				return
-			}
-
-			_, err = git.PlainClone(dir, false, &git.CloneOptions{
-				Auth:     sshAuth,
-				URL:      r.GetSSHURL(),
+			_, err := git.PlainClone(dir, false, &git.CloneOptions{
+				// go-git does not yet support TokenAuth (https://godoc.org/gopkg.in/src-d/go-git.v4/plumbing/transport/http#TokenAuth)
+				// you will recieve and error similar to the following:
+				// unexpected client error: unexpected requesting ... status code: 400
+				// instead, you must use BasicAuth with your GitHub Access Token as the password
+				// and the Username can be anything.
+				Auth: &http.BasicAuth{
+					Username: "abc123", // yes, this can be anything except an empty string
+					Password: ctx.GitHub.AccessToken,
+				},
+				URL:      r.GetCloneURL(),
 				Progress: os.Stdout,
 			})
 			if err != nil {
-				ctx.Logger.Errorf("failed to clone project %s with error %+v", *r.Name, err)
+				ctx.Logger.Errorf("failed to clone project %s with error: %+v", *r.Name, err)
 				return
 			}
 

--- a/pkg/neighbor/cmd.go
+++ b/pkg/neighbor/cmd.go
@@ -1,7 +1,6 @@
 package neighbor
 
 // stdlib
-
 // external
 // internal
 

--- a/pkg/neighbor/context.go
+++ b/pkg/neighbor/context.go
@@ -3,10 +3,10 @@ package neighbor
 import (
 	// stdlib
 	"context"
+	"os"
 	"os/exec"
 
 	// external
-
 	log "github.com/sirupsen/logrus"
 
 	// internal
@@ -18,14 +18,26 @@ import (
 // This does NOT satisfice the context.Context interface (https://golang.org/pkg/context/#Context),
 // therefore, it cannot be used as a context for methods or functions requiring a context.Context.
 type Ctx struct {
-	Config        *config.Config    // the query config created by the user
-	Context       context.Context   // a context object required by the GitHub SDK
-	Logger        *log.Logger       // the logger to be used throughout the project
+	Config        *config.Config  // the query config created by the user
+	Context       context.Context // a context object required by the GitHub SDK
+	Logger        *log.Logger     // the logger to be used throughout the project
+	NeighborDir   string
 	ProjectDirMap map[string]string // key: project name, value: absolute path to directory
+	ExtResultDir  string            // where the external projects and test results will be stored
 	TestCmd       *exec.Cmd         // external project test command
 }
 
 // NewCtx creates a pointer to a new neighbor context.
 func NewCtx() *Ctx {
 	return &Ctx{}
+}
+
+// CreateExternalResultDir creates the external projects and results directory if
+// it doesn't exist.
+func (ctx *Ctx) CreateExternalResultDir() error {
+	_, err := os.Stat(ctx.ExtResultDir)
+	if os.IsNotExist(err) {
+		return os.Mkdir(ctx.ExtResultDir, os.ModePerm)
+	}
+	return nil
 }

--- a/pkg/neighbor/context.go
+++ b/pkg/neighbor/context.go
@@ -20,11 +20,17 @@ import (
 type Ctx struct {
 	Config        *config.Config  // the query config created by the user
 	Context       context.Context // a context object required by the GitHub SDK
-	Logger        *log.Logger     // the logger to be used throughout the project
+	GitHub        GitHubDetails
+	Logger        *log.Logger // the logger to be used throughout the project
 	NeighborDir   string
 	ProjectDirMap map[string]string // key: project name, value: absolute path to directory
 	ExtResultDir  string            // where the external projects and test results will be stored
 	TestCmd       *exec.Cmd         // external project test command
+}
+
+// GitHubDetails are GitHub-specifc details necessary throughout the project
+type GitHubDetails struct {
+	AccessToken string
 }
 
 // NewCtx creates a pointer to a new neighbor context.


### PR DESCRIPTION
- [x] improve Makefile to not overwrite backup `go` commands
+ added shell scripts ./build/setup.sh and ./build/cleanup.sh for setting up and cleaning up, respectively
- [x] store coverprofile for each project in project root (or possibly neighbor/ parent directory)
   + use a `COVERPROFILE_PATH_OUT` environment file set by neighbor and used by the `go` binary to determine where to write coverprofile
   + https://github.com/mccurdyc/go/pull/1
   + https://github.com/mccurdyc/neighbor/pull/6
   + still need to document this so that users could see this fork and update it themselves
- [x] create neighbor/ parent directory where GitHub projects will all be cloned
+ creates a `ext-results/` directory in the current working directory if it does not exist
Q: should we clean this upon every run?
T: my thought is probably not. because, what if someone wanted to add additional projects to the analysis without re-running on old projects? maybe we should add a `make` target or something for cleaning.
- [ ] @Michionlion investigate issue with custom-built `go` command
- [ ] get a better understanding of the coverprofile output from `go test -coverprofile=c.out`
- [x] improve documentation for using `ssh` for `git`
+ use token authentication instead of SSH
- [x] improve documentation for creating a `config.json` file 
+ this is now part of the `make setup` command and documentation