### PR TITLE
Colton/coverprofile out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ vendor/
 config.yml
 config.json
 ext-results/
+_ext-results/
 

--- a/cmd/neighbor/main.go
+++ b/cmd/neighbor/main.go
@@ -42,7 +42,18 @@ func main() {
 		Logger:        l,
 		NeighborDir:   wd,
 		ProjectDirMap: make(map[string]string),
-		ExtResultDir:  fmt.Sprintf("%s/%s", wd, "ext-results"),
+		ExtResultDir:  fmt.Sprintf("%s/%s", wd, "_ext-results"), // go tools handle directories prepended with '_' differently; often they ignore those directories
+	}
+
+	ll := os.Getenv("LOG_LEVEL")
+	if len(ll) == 0 {
+		ctx.Logger.SetLevel(log.InfoLevel)
+	} else {
+		ll, err := log.ParseLevel(ll)
+		if err != nil {
+			ctx.Logger.SetLevel(log.InfoLevel)
+		}
+		ctx.Logger.SetLevel(ll)
 	}
 
 	err = ctx.CreateExternalResultDir()

--- a/pkg/external/test.go
+++ b/pkg/external/test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	// external
+	"github.com/google/uuid"
 
 	// internal
 	"github.com/mccurdyc/neighbor/pkg/neighbor"
@@ -18,11 +19,20 @@ func RunTests(ctx *neighbor.Ctx) {
 
 		err := os.Chdir(dir)
 		if err != nil {
-			ctx.Logger.Error(err)
+			ctx.Logger.Errorf("error changing into %s directory: %+v", name, err)
 			continue
 		}
 
-		cp := fmt.Sprintf("%s/neighbor-%s-coverprofile.out", dir, name)
+		// we need to append a globally unique identifier to the coverprofile
+		// path because a project could have multiple coverage profiles from multiple
+		// packages and we want to store them all in the root of the project with an
+		// easily-identifiable name "neighbor-projectname-coverprofile-UUID.out"
+		guuid, err := uuid.NewRandom()
+		if err != nil {
+			ctx.Logger.Errorf("error generating new random UUID: %+v", err)
+		}
+
+		cp := fmt.Sprintf("%s/neighbor-%s-coverprofile-%s.out", dir, name, guuid.String())
 
 		err = os.Setenv("COVERPROFILE_OUT_PATH", cp)
 		ctx.Logger.Infof("setting COVERPROFILE_OUT_PATH for %s to (%s)", name, cp)

--- a/pkg/external/test.go
+++ b/pkg/external/test.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	// stdlib
+	"fmt"
 	"os"
 
 	// external
@@ -14,7 +15,17 @@ import (
 func RunTests(ctx *neighbor.Ctx) {
 	for name, dir := range ctx.ProjectDirMap {
 		ctx.Logger.Infof("running tests for %s", name)
+
 		err := os.Chdir(dir)
+		if err != nil {
+			ctx.Logger.Error(err)
+			continue
+		}
+
+		cp := fmt.Sprintf("%s/neighbor-%s-coverprofile.out", dir, name)
+
+		err = os.Setenv("COVERPROFILE_OUT_PATH", cp)
+		ctx.Logger.Infof("setting COVERPROFILE_OUT_PATH for %s to (%s)", name, cp)
 		if err != nil {
 			ctx.Logger.Error(err)
 			continue

--- a/pkg/github/clone.go
+++ b/pkg/github/clone.go
@@ -59,6 +59,8 @@ func CloneFromResult(ctx *neighbor.Ctx, c *github.Client, d interface{}) {
 			ctx.Logger.Infof("cloned: %s", r.GetCloneURL())
 
 			ctx.ProjectDirMap[*r.Name] = dir
+
+			ctx.Logger.Infof("Project Directory Map: %+v", ctx.ProjectDirMap)
 		}
 
 		return


### PR DESCRIPTION
## Proposed Changes
+ set `COVERPROFILE_OUT_PATH` environment variable for the `go` binary to use to determine where to write coverprofile anytime go test is run.

## Relevant Pull Requests
+ https://github.com/mccurdyc/go/pull/1