### PR TITLE
Clone and Test Pipelining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: build
 	cp bin/neighbor /usr/local/bin
 
 run: build
-	./bin/neighbor -filepath $(PWD)/config.yml
+	./bin/neighbor -filepath $(PWD)/config.json
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -60,5 +60,15 @@ A neighborhood watch tool for evaluating neighbors' test suite adequacy in the n
     make run
     ```
 
+    The `run` target will first build neighbor and then invoke neighbor pointed
+    at the config.json file in the root of the project.
+
+    neighbor will use the GitHub query specified in the config file to find projects
+    on GitHub. neighbor will then clone and test each of these projects sequentially
+    using the test command specified in the config. neighbor will use a custom go binary
+    instead of the default go binary. This custom go binary always enables the
+    `-coverprofile` flag during `go test` and writes to a easy-to-find location
+    at the root of each project in the `_ext-results/` directory.
+
 ## License
 + [GNU General Public License Version 3](./LICENSE)

--- a/cmd/neighbor/main.go
+++ b/cmd/neighbor/main.go
@@ -7,6 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	// external
 	log "github.com/sirupsen/logrus"
@@ -32,17 +35,32 @@ func main() {
 		os.Exit(1)
 	}
 
+	c, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		ch := make(chan os.Signal, 1)
+
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		select {
+		case <-c.Done():
+		case <-ch:
+			cancel()
+		}
+	}()
+
 	// create a context object that will be used for the life of the program and passed around
 	ctx := &neighbor.Ctx{
 		Config:  cfg,
-		Context: context.Background(),
+		Context: c,
 		GitHub: neighbor.GitHubDetails{
 			AccessToken: cfg.Contents.AccessToken,
 		},
-		Logger:        l,
-		NeighborDir:   wd,
-		ProjectDirMap: make(map[string]string),
-		ExtResultDir:  fmt.Sprintf("%s/%s", wd, "ext-results"),
+		Logger:       l,
+		NeighborDir:  wd,
+		ExtResultDir: fmt.Sprintf("%s/%s", wd, "ext-results"),
 	}
 
 	err = ctx.CreateExternalResultDir()
@@ -56,10 +74,22 @@ func main() {
 	ctx.Logger.Debugf("github search response: %+v", resp)
 	ctx.Logger.Debugf("github search result: %+v", res)
 
-	// populates the context's ProjectDirMap with cloned projects and where they were cloned
-	github.CloneFromResult(ctx, svc.Client, res)
-
 	neighbor.SetTestCmd(ctx)
 
-	external.RunTests(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		ch := github.CloneFromResult(ctx, svc.Client, res)
+		external.RunTests(ctx, ch)
+
+		select {
+		case <-ctx.Context.Done():
+			return
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/prometheus/common/log"
 	// external
@@ -21,7 +19,6 @@ type Contents struct {
 	Query       string `json:"query"`
 
 	TestCmdStr string `json:"external_test_command"`
-	TestCmd    *exec.Cmd
 }
 
 // Config specifies information about the config file used for performing the experiment.
@@ -53,13 +50,6 @@ func (cfg *Config) Parse() {
 	}
 
 	cfg.Contents = c
-
-	// set external test command
-	if len(cfg.Contents.TestCmdStr) != 0 {
-		s := strings.Split(cfg.Contents.TestCmdStr, " ")
-		cfg.Contents.TestCmd = exec.Command(s[0], s[1:]...)
-	}
-
 	return
 }
 

--- a/pkg/external/test.go
+++ b/pkg/external/test.go
@@ -40,10 +40,10 @@ func RunTests(ctx *neighbor.Ctx, ch <-chan github.ExternalProject) {
 				ctx.Logger.Errorf("error generating new random UUID: %+v", err)
 			}
 
-			cp := fmt.Sprintf("%s/neighbor-%s-coverprofile-%s.out", dir, name, guuid.String())
+			cp := fmt.Sprintf("%s/neighbor-%s-coverprofile-%s.out", p.Directory, p.Name, guuid.String())
 
 			err = os.Setenv("COVERPROFILE_OUT_PATH", cp)
-			ctx.Logger.Infof("setting COVERPROFILE_OUT_PATH for %s to (%s)", name, cp)
+			ctx.Logger.Infof("setting COVERPROFILE_OUT_PATH for %s to (%s)", p.Name, cp)
 			if err != nil {
 				ctx.Logger.Error(err)
 				continue

--- a/pkg/external/test.go
+++ b/pkg/external/test.go
@@ -42,6 +42,9 @@ func RunTests(ctx *neighbor.Ctx, ch <-chan github.ExternalProject) {
 
 			cp := fmt.Sprintf("%s/neighbor-%s-coverprofile-%s.out", p.Directory, p.Name, guuid.String())
 
+			// I do have concerns setting an environment variable if we do end up processing
+			// projects concurrently. This environment variable could be overwritten in
+			// another goroutine.
 			err = os.Setenv("COVERPROFILE_OUT_PATH", cp)
 			ctx.Logger.Infof("setting COVERPROFILE_OUT_PATH for %s to (%s)", p.Name, cp)
 			if err != nil {
@@ -49,6 +52,9 @@ func RunTests(ctx *neighbor.Ctx, ch <-chan github.ExternalProject) {
 				continue
 			}
 
+			// we can't parse the command outside of this loop because exec.Command creates
+			// a pointer to a Cmd and if you call Run() on that command, it will say
+			// that it is already processing.
 			var cmd *exec.Cmd
 			if len(ctx.TestCmd) == 1 {
 				cmd = exec.Command(ctx.TestCmd[0])

--- a/pkg/external/test.go
+++ b/pkg/external/test.go
@@ -3,29 +3,60 @@ package external
 import (
 	// stdlib
 	"os"
+	"os/exec"
 
 	// external
 
 	// internal
+	"github.com/mccurdyc/neighbor/pkg/github"
 	"github.com/mccurdyc/neighbor/pkg/neighbor"
 )
 
 // RunTests runs the tests of an external project using the context's TestCmd.
-func RunTests(ctx *neighbor.Ctx) {
-	for name, dir := range ctx.ProjectDirMap {
-		ctx.Logger.Infof("running tests for %s", name)
-		err := os.Chdir(dir)
-		if err != nil {
-			ctx.Logger.Error(err)
-			continue
+func RunTests(ctx *neighbor.Ctx, ch <-chan github.ExternalProject) {
+	run := func(ch <-chan github.ExternalProject) {
+		for p := range ch {
+
+			ctx.Logger.Infof("running tests for %s", p.Name)
+			err := os.Chdir(p.Directory)
+			if err != nil {
+				ctx.Logger.Error(err)
+				continue
+			}
+
+			if len(ctx.TestCmd) < 1 {
+				ctx.Logger.Errorf("test command cannot be empty")
+				return
+			}
+
+			var cmd *exec.Cmd
+			if len(ctx.TestCmd) == 1 {
+				cmd = exec.Command(ctx.TestCmd[0])
+			} else {
+				cmd = exec.Command(ctx.TestCmd[0], ctx.TestCmd[1:]...)
+			}
+
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				ctx.Logger.Errorf("failed to run test command with error %+v", err)
+				continue
+			}
 		}
 
-		ctx.TestCmd.Stdout = os.Stdout
-		ctx.TestCmd.Stderr = os.Stderr
-
-		if err := ctx.TestCmd.Run(); err != nil {
-			ctx.Logger.Errorf("failed to run test command with error %+v", err)
-			continue
+		select {
+		case <-ctx.Context.Done():
+			return
 		}
 	}
+
+	go func() {
+		run(ch)
+
+		select {
+		case <-ctx.Context.Done():
+			return
+		}
+	}()
 }

--- a/pkg/github/clone.go
+++ b/pkg/github/clone.go
@@ -24,49 +24,63 @@ type ClonedRepositoriesCtxKey struct{}
 // path to where the repository was cloned.
 type repoDirMap map[string]string
 
+// ExternalProject contains a GitHub project's name as where it was cloned to
+type ExternalProject struct {
+	Name      string
+	Directory string
+}
+
 // CloneFromResult creates temporary directories where the base path is that of os.TempDir
 // and the rest of the path is the Name of the repository. After creating a temporary
 // directory, a project is cloned into that directory. After creating temp directories
 // and cloning projects into the respective directory, the context is updated
 // with the project names and the temporary directories.
-func CloneFromResult(ctx *neighbor.Ctx, c *github.Client, d interface{}) {
-	switch t := d.(type) {
-	case *github.RepositoriesSearchResult:
-		for _, r := range t.Repositories {
+func CloneFromResult(ctx *neighbor.Ctx, c *github.Client, d interface{}) <-chan ExternalProject {
+	// create a buffered channel that will have at most a single element at a time
+	ch := make(chan ExternalProject, 1)
 
-			ctx.Logger.Debugf("%+v", r)
-			dir := fmt.Sprintf("%s/%s", ctx.ExtResultDir, *r.Name)
-			ctx.Logger.Infof("created directory: %s", dir)
+	go func() {
+		defer close(ch)
 
-			_, err := git.PlainClone(dir, false, &git.CloneOptions{
-				// go-git does not yet support TokenAuth (https://godoc.org/gopkg.in/src-d/go-git.v4/plumbing/transport/http#TokenAuth)
-				// you will recieve and error similar to the following:
-				// unexpected client error: unexpected requesting ... status code: 400
-				// instead, you must use BasicAuth with your GitHub Access Token as the password
-				// and the Username can be anything.
-				Auth: &http.BasicAuth{
-					Username: "abc123", // yes, this can be anything except an empty string
-					Password: ctx.GitHub.AccessToken,
-				},
-				URL:      r.GetCloneURL(),
-				Progress: os.Stdout,
-			})
-			if err != nil {
-				ctx.Logger.Errorf("failed to clone project %s with error: %+v", *r.Name, err)
-				return
+		switch t := d.(type) {
+		case *github.RepositoriesSearchResult:
+			for _, r := range t.Repositories {
+
+				ctx.Logger.Debugf("%+v", r)
+				dir := fmt.Sprintf("%s/%s", ctx.ExtResultDir, *r.Name)
+				ctx.Logger.Infof("created directory: %s", dir)
+
+				_, err := git.PlainClone(dir, false, &git.CloneOptions{
+					// go-git does not yet support TokenAuth (https://godoc.org/gopkg.in/src-d/go-git.v4/plumbing/transport/http#TokenAuth)
+					// you will recieve and error similar to the following:
+					// unexpected client error: unexpected requesting ... status code: 400
+					// instead, you must use BasicAuth with your GitHub Access Token as the password
+					// and the Username can be anything.
+					Auth: &http.BasicAuth{
+						Username: "abc123", // yes, this can be anything except an empty string
+						Password: ctx.GitHub.AccessToken,
+					},
+					URL:      r.GetCloneURL(),
+					Progress: os.Stdout,
+				})
+				if err != nil {
+					ctx.Logger.Errorf("failed to clone project %s with error: %+v", *r.Name, err)
+					continue
+				}
+
+				ctx.Logger.Infof("cloned: %s", r.GetCloneURL())
+
+				select {
+				case ch <- ExternalProject{
+					Name:      *r.Name,
+					Directory: dir,
+				}:
+				case <-ctx.Context.Done():
+					return
+				}
 			}
-
-			ctx.Logger.Infof("cloned: %s", r.GetCloneURL())
-
-			ctx.ProjectDirMap[*r.Name] = dir
 		}
+	}()
 
-		return
-	case *github.CodeSearchResult:
-		// needs implemented
-	default:
-		return
-	}
-
-	return
+	return ch
 }

--- a/pkg/neighbor/cmd.go
+++ b/pkg/neighbor/cmd.go
@@ -1,10 +1,12 @@
 package neighbor
 
+import "strings"
+
 // stdlib
 // external
 // internal
 
 // SetTestCmd sets the test command that will be run on external projects.
 func SetTestCmd(c *Ctx) {
-	c.TestCmd = c.Config.Contents.TestCmd
+	c.TestCmd = strings.Split(c.Config.Contents.TestCmdStr, " ")
 }

--- a/pkg/neighbor/context.go
+++ b/pkg/neighbor/context.go
@@ -4,7 +4,6 @@ import (
 	// stdlib
 	"context"
 	"os"
-	"os/exec"
 
 	// external
 	log "github.com/sirupsen/logrus"
@@ -18,14 +17,13 @@ import (
 // This does NOT satisfice the context.Context interface (https://golang.org/pkg/context/#Context),
 // therefore, it cannot be used as a context for methods or functions requiring a context.Context.
 type Ctx struct {
-	Config        *config.Config  // the query config created by the user
-	Context       context.Context // a context object required by the GitHub SDK
-	GitHub        GitHubDetails
-	Logger        *log.Logger // the logger to be used throughout the project
-	NeighborDir   string
-	ProjectDirMap map[string]string // key: project name, value: absolute path to directory
-	ExtResultDir  string            // where the external projects and test results will be stored
-	TestCmd       *exec.Cmd         // external project test command
+	Config       *config.Config  // the query config created by the user
+	Context      context.Context // a context object required by the GitHub SDK
+	GitHub       GitHubDetails
+	Logger       *log.Logger // the logger to be used throughout the project
+	NeighborDir  string
+	ExtResultDir string   // where the external projects and test results will be stored
+	TestCmd      []string // external project test command and args
 }
 
 // GitHubDetails are GitHub-specifc details necessary throughout the project


### PR DESCRIPTION
+ instead of having to clone all projects before testing, we should clone and test a single project
+ to do this, we use go channels, specifically a buffered channel, with a buffer size of 1.
+ the buffer size of 1 is important because we still are using the environment variable to tell `go test` where to write the coverage profile. If we do handle this concurrently, we need to find a better way to inform `go test` of where to write.
  + one thought is we write to some generic `neighbor-coverprofile.out` then in neighbor, after performing all tests on a project, do the collation that would recursively search through subdirectories of a project looking for `neighbor-coverprofile.out` files.